### PR TITLE
Somando 2 ciclos a mais no último teste (tendo dez pedidos sortidos)

### DIFF
--- a/test.c
+++ b/test.c
@@ -187,8 +187,8 @@ void test_sortidos(){
     THEN("Espero que use o barramento e a CPU todo o tempo");
     struct result_io * r;
     r = sim_io(configs, "t7.txt", 0); 
-    isEqual(r->busy, 30228, 1);
-    isEqual(r->cpu_usage, 7228, 1);
+    isEqual(r->busy, 30226, 1);
+    isEqual(r->cpu_usage, 7226, 1);
     PRINT_RESULTS(r);
     PRINT_REQS(r, 9); //9 requests
     CLEANUP(r);


### PR DESCRIPTION
No último teste do gabarito, tendo dez pedidos sortidos está dando o seguinte resultado:
r->busy = 30228 ciclos
r->cpu_usage = 7228 ciclos.

Ao executar o teste sem considerar os 2 bytes de interrupção para cada um dos dispositivos, o resultado é:
r->busy =  29992 (Nota do professor: é 29996)
r->cpu_usage = 6992 

Considerando os 2 bytes de interrupção para os dispositivos DMA, temos:
Disco(A): 2 bytes de interrupção
Disco(B): 2 bytes de interrupção
Video: 2 bytes de interrupção
Rede: 2 bytes de interrupção
Resultado: 2 + 2 + 2 + 2 = 8 ciclos (Nota do professor: não está calculando conforme velocidade dos dispositivos)

Para os dispositivos de interrupção temos:
USB: 2 bytes de interrupção * 3 ciclos por byte = 6 
Som: 2 bytes de interrupção * 10 = 20
Teclado: 2 bytes de interrupção * 100 = 200
Resultado: 6 + 20 + 200 = 226 ciclos

Logo o resultado final é:
r->busy: 29992 + 8 (DMA) + 226 (Int) = 30226 ciclos
r->cpu_usage: 6992 + 8 (DMA) + 226 (Int) = 7226 ciclos

Passos para repetir:
1. Execute o teste com o rdsnascimento/gabarito_a03_2017_2, commit a2860185171f54e0a52d87bade59a065d7f4eb7f
2. Na linha 190, r->busy está com 30228, mas deveria ser 30226 e na linha 191, r->cpu_usage está com 7228, mas o resultado deveria ser 7226.

Patch em anexo.
[test.zip](https://github.com/ufpelaoc2/gabarito_a03_2017_2/files/1745769/test.zip)

Aluno: Rafael Nascimento
rdsnascimento@inf.ufpel.edu.br